### PR TITLE
K8s scratch

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -12,9 +12,9 @@ COPY dev /usr/src/app/dev
 COPY resources /usr/src/app/resources
 COPY dev-resources /usr/src/app/dev-resources
 
-RUN lein deps
+RUN lein with-profile k8s,dev deps
 
-CMD ["lein", "repl", ":headless", ":host", "127.0.0.1", ":port", "7888" ] 
+CMD ["lein", "with-profile", "k8s,dev", "repl", ":headless", ":host", "127.0.0.1", ":port", "7888" ] 
 
 EXPOSE 3000 
 EXPOSE 7888 

--- a/README.md
+++ b/README.md
@@ -162,11 +162,13 @@ When run in dev mode, skaffold will do the following:
 The command to run skaffold in this scenario is:
 
 ```
-skaffold dev --port-forward
+skaffold dev --port-forward --trigger=manual
 ```
 
-And once it settles, you can connect to the nrepl server forwarded to `localhost:7888`, eval `(start)`, and you'll have a fresh development
-environment that can scale if needed and is easy to clean up.
+And once it settles, you can connect to the nrepl server forwarded to `localhost:7888`, and you'll have a fresh development
+environment that can scale if needed and is easy to clean up.  Note that with the addition of a startup probe and liveness checks,
+`(start)` is now called automatically, as Kubernetes will recycle the CTIA container if it doesn't repond to a HTTP GET on "/" within
+a certain time frame.  To trigger a refresh of the environment, press return when you terminal running skaffold has focus.
 
 
 #### Limitations

--- a/k8s/03-40_ctia_deployment.yaml
+++ b/k8s/03-40_ctia_deployment.yaml
@@ -29,6 +29,17 @@ spec:
             name: api
           - containerPort: 7888
             name: repl
+        startupProbe:
+          httpGet:
+            path: /
+            port: api
+          periodSeconds: 10
+          failureThreshold:  12
+        livenessProbe:
+          httpGet:
+            path: /
+            port: api
+          periodSeconds: 5
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       volumes:

--- a/project.clj
+++ b/project.clj
@@ -183,6 +183,8 @@
                    :pedantic? :warn
                    :resource-paths ["test/resources"]
                    :source-paths ["dev"]}
+             :k8s {:repl-options {:init-ns user
+                                  :init (start)}}
              :ci {:pedantic? :abort
                   :global-vars {*warn-on-reflection* true}}
              :next-clojure {:dependencies [[org.clojure/clojure "1.10.2-rc1"]]}


### PR DESCRIPTION
Added Startup probe and liveness probe to the Kubernetes development environment.  Note that in addition to starting the repl, ctia is started automatically via (user/start).